### PR TITLE
Update for iptables vs firewalld

### DIFF
--- a/mcafee-agent/elx/init.sls
+++ b/mcafee-agent/elx/init.sls
@@ -15,6 +15,18 @@ Install McAfee Agent Dependencies:
       - unzip
 
 {%- for port in mcafee.client_in_ports %}
+  {%- if salt.grains.get('osmajorrelease') == '7'%}
+    {%- set FwZone = salt.firewalld.default_zone() %}
+Allow ePO Mgmt Inbound Port {{ port }}:
+  module.run:
+    - name: 'firewalld.add_port'
+    - zone: '{{ FwZone }}'
+    - port: '{{ port }}/tcp'
+    - permanent: True
+Reload firewalld for McAfee Outbound Port {{ port }}:
+  module.run:
+    - name: firewalld.reload_rules
+  {%- elif salt.grains.get('osmajorrelease') == '6'%}
 Allow ePO Mgmt Inbound Port {{ port }}:
   iptables.append:
     - table: filter
@@ -30,6 +42,7 @@ Allow ePO Mgmt Inbound Port {{ port }}:
     - save: True
     - require_in:
       - file: Stage McAfee Install Archive
+  {%- endif %}
 {%- endfor %}
 
 Stage McAfee Install Archive:


### PR DESCRIPTION
Closes #2
* first-cut branching logic:
  - Split elx/init.sls by salt-grain `osmajorrelease`
  - Move current iptables logic to `osmajorrelease == 6` branch
  - Add firewalld logic to `osmajorrelease == 7` branch

We use module.run because screw it, it's dinner time