### PR TITLE
Adds `ed` pkg as a dependency for the mcafee agent

### DIFF
--- a/mcafee-agent/elx/init.sls
+++ b/mcafee-agent/elx/init.sls
@@ -13,6 +13,7 @@ Install McAfee Agent Dependencies:
   pkg.installed:
     - pkgs:
       - unzip
+      - ed
 
 {%- for port in mcafee.client_in_ports %}
   {%- if salt.grains.get('osmajorrelease') == '7'%}


### PR DESCRIPTION
Technically, the dependency is for the VSEL installer, but this seems like a good place to ensure the pkg is installed.

Fixes #6 